### PR TITLE
documentation/README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # surely
+## a humble chrome extension 
+
+When enabled on your browser, surely draws attention to signals of certainty in a body of text, signals that may make the certainty they're intended to communicate suspicious. 
+
+> “Not always, not even most of the time, but often the word “surely” is as good as a blinking light locating a weak point in the argument ... Why? Because it marks the very edge of what the author is actually sure about and hopes readers will also be sure about.”
+
+>> from Daniel C. Dennett, "The “Surely” Operator: A Mental Block” in *Intuition Pumps And Other Tools for Thinking.*

--- a/README.md
+++ b/README.md
@@ -1,8 +1,26 @@
 # surely
 ## a humble chrome extension 
 
-When enabled on your browser, surely draws attention to signals of certainty in a body of text, signals that may make the certainty they're intended to communicate suspicious. 
+When enabled on a browser, ***surely*** draws attention to signals of certainty in a body of text.
+The tool was inspired by "The “Surely” Operator: A Mental Block” in Daniel C. Dennett's *Intuition Pumps And Other Tools for Thinking*:
 
-> “Not always, not even most of the time, but often the word “surely” is as good as a blinking light locating a weak point in the argument ... Why? Because it marks the very edge of what the author is actually sure about and hopes readers will also be sure about.”
+> “Not always, not even most of the time, but often the word 'surely' is as good as a blinking light locating a weak point in the argument ... Why? Because it marks the very edge of what the author is actually sure about and hopes readers will also be sure about.”
 
->> from Daniel C. Dennett, "The “Surely” Operator: A Mental Block” in *Intuition Pumps And Other Tools for Thinking.*
+By default, the extension flags uses of the word "surely" as well as
+- obviously
+- naturally
+- of course
+- incontrovertibly
+- indupitably
+- undoubtedly
+- doubtless
+- it goes without saying
+- of course
+- undeniably
+- unmistakably
+- without question
+
+A user can deselect any of these words or phrases and add a limited number of custom strings to flag. They can also view a page's certainty-signaling score relative to ***surely***'s standardized scoring system and their personal ***surely*** history.
+
+
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## a humble chrome extension 
 
 When enabled on a browser, ***surely*** draws attention to signals of certainty in a body of text.
-The tool was inspired by "The “Surely” Operator: A Mental Block” in Daniel C. Dennett's *Intuition Pumps And Other Tools for Thinking*:
+The tool was inspired by "The 'Surely' Operator: A Mental Block” in Daniel C. Dennett's *Intuition Pumps And Other Tools for Thinking*:
 
 > “Not always, not even most of the time, but often the word 'surely' is as good as a blinking light locating a weak point in the argument ... Why? Because it marks the very edge of what the author is actually sure about and hopes readers will also be sure about.”
 


### PR DESCRIPTION
#### Overview
- adds title and headline to README
- explains basic (planned) functionality of extension
- credits Daniel Dennett for inspiration

#### Underview
documentation changes only

#### Context
none of the functionality is built yet: readme intro here serving as planning tool
 
#### Notes